### PR TITLE
Correct library installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ That should be everything you need for wiring. If something isn't working, it mi
 
 ## Arduino Setup
 
-To setup the Arduino, simply upload the sketch using the Arduino IDE. You will need to add the [MAX6675 library](https://github.com/adafruit/MAX6675-library) and the [ModbusRTU](https://github.com/smarmengol/Modbus-Master-Slave-for-Arduino) library. You can install both of these using the [Arduino Library Manager](https://www.arduino.cc/en/Guide/Libraries#toc3).
+To setup the Arduino, simply upload the sketch using the Arduino IDE. You will need to add the [MAX6675 library](https://github.com/adafruit/MAX6675-library) (which you can install using the [Arduino Library Manager](https://www.arduino.cc/en/Guide/Libraries#toc3)) and the [ModbusRTU](https://github.com/smarmengol/Modbus-Master-Slave-for-Arduino) library (which you can install [from the downloaded .zip file](https://www.arduino.cc/en/Guide/Libraries#toc4)).
 
 ## Modbus
 Modbus is a serial communication protocol used in lots of industrial equipment, including many industrial coffee roasters. This project uses Modbus so that the Arduino can easily interface with Artisan RoasterScope software as well as any commercial coffee roasting software that supports the Modbus protocol.


### PR DESCRIPTION
Previously, the instructions said that both libraries can be installed via Library Manager but ModbusRTU is not in the Arduino Library Manager index so this is not correct.